### PR TITLE
Downloading folder settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import os
+from os.path import join
 from bpy.utils import register_class, unregister_class
 from bpy.types import Menu
 from bpy.types import Header
@@ -49,7 +49,7 @@ class ApiAddonPreferences(AddonPreferences):
         name = "Common folder path for download",
         description = "Common folder path where freesound downloads are stored",
         subtype = 'DIR_PATH',
-        default = os.path.join(bpy.utils.user_resource('DATAFILES'), "freesound_downloads")
+        default = join(bpy.utils.user_resource('DATAFILES'), "freesound_downloads")
     )
 
     freesound_access : BoolProperty()

--- a/__init__.py
+++ b/__init__.py
@@ -46,8 +46,8 @@ class ApiAddonPreferences(AddonPreferences):
     )
 
     freesound_download_folderpath : StringProperty(
-        name = "Download folder path",
-        description = "Folder path where freesound downloads are stored",
+        name = "Common folder path for download",
+        description = "Common folder path where freesound downloads are stored",
         subtype = 'DIR_PATH',
         default = os.path.join(bpy.utils.user_resource('DATAFILES'), "freesound_downloads")
     )

--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,7 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
-import os.path
+import os
 from bpy.utils import register_class, unregister_class
 from bpy.types import Menu
 from bpy.types import Header
@@ -39,6 +39,26 @@ class ApiAddonPreferences(AddonPreferences):
         default = "Get it here http://www.freesound.org/apiv2/apply/"
     )
 
+    freesound_project_folder : BoolProperty(
+        name = "Download alongside blend",
+        default = True,
+        description = "Download from freesound in a specific folder alongside blend file"
+    )
+
+    freesound_project_folder_pattern : StringProperty(
+        name = "Folder name for download",
+        description = "Folder name for download in a specific folder alongside blend file",
+        subtype = 'DIR_PATH',
+        default = "freesound_downloads"
+    )
+
+    freesound_download_folderpath : StringProperty(
+        name = "Download folder path",
+        description = "Folder path where freesound downloads are stored",
+        subtype = 'DIR_PATH',
+        default = os.path.join(bpy.utils.user_resource('DATAFILES'), "freesound_downloads")
+    )
+
     freesound_access : BoolProperty()
 
     def draw(self, context):
@@ -48,12 +68,18 @@ class ApiAddonPreferences(AddonPreferences):
             layout.operator("freesound.validate", text="Validated")
         else:
             layout.operator("freesound.validate", text="Validate your API Key")
-    
+
+        layout.prop(self, "freesound_project_folder")
+        if self.freesound_project_folder:
+            layout.prop(self, "freesound_project_folder_pattern")
+        else:
+            layout.prop(self, "freesound_download_folderpath")
+
 
 bl_info = {
     "name": "Freesound",
-    "author": "Salvatore De Paolis",
-    "version": (2, 0),
+    "author": "Salvatore De Paolis, tin2tin, tonton",
+    "version": (2, 1),
     "blender": (2, 80, 0),
     "category": "Sequencer",
     "location": "Sequencer",

--- a/__init__.py
+++ b/__init__.py
@@ -42,7 +42,6 @@ class ApiAddonPreferences(AddonPreferences):
     freesound_project_folder_pattern : StringProperty(
         name = "Folder name for download",
         description = "Folder name for download in a specific folder alongside blend file",
-        subtype = 'DIR_PATH',
         default = "freesound_downloads"
     )
 
@@ -57,14 +56,17 @@ class ApiAddonPreferences(AddonPreferences):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(self, "freesound_api")
-        if (self.freesound_access):
-            layout.operator("freesound.validate", text="Validated")
-        else:
-            layout.operator("freesound.validate", text="Validate your API Key")
 
-        layout.prop(self, "freesound_project_folder_pattern")
-        layout.prop(self, "freesound_download_folderpath")
+        box = layout.box()
+        box.prop(self, "freesound_api")
+        if (self.freesound_access):
+            box.operator("freesound.validate", text="Validated")
+        else:
+            box.operator("freesound.validate", text="Validate your API Key")
+
+        box = layout.box()
+        box.prop(self, "freesound_project_folder_pattern")
+        box.prop(self, "freesound_download_folderpath")
 
 
 bl_info = {

--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,7 @@ from bpy.types import Header
 from bpy.types import Scene
 from bpy.types import Operator, AddonPreferences
 from bpy.props import StringProperty, BoolProperty, PointerProperty
-from .ui import FREESOUND_PT_Panel
+from .ui import *
 from .freesound import *
 
 class ApiAddonPreferences(AddonPreferences):
@@ -107,6 +107,8 @@ classes = (
         Freesound_First,
         Freesound_Pause,
         FREESOUND_PT_Panel,
+        FREESOUND_PT_subpanel_search,
+        FREESOUND_PT_subpanel_settings,
 )
 
 # Registration

--- a/__init__.py
+++ b/__init__.py
@@ -71,7 +71,7 @@ class ApiAddonPreferences(AddonPreferences):
 
 bl_info = {
     "name": "Freesound",
-    "author": "Salvatore De Paolis, tin2tin, tonton",
+    "author": "Salvatore De Paolis",
     "version": (2, 1),
     "blender": (2, 80, 0),
     "category": "Sequencer",

--- a/__init__.py
+++ b/__init__.py
@@ -39,12 +39,6 @@ class ApiAddonPreferences(AddonPreferences):
         default = "Get it here http://www.freesound.org/apiv2/apply/"
     )
 
-    freesound_project_folder : BoolProperty(
-        name = "Download alongside blend",
-        default = True,
-        description = "Download from freesound in a specific folder alongside blend file"
-    )
-
     freesound_project_folder_pattern : StringProperty(
         name = "Folder name for download",
         description = "Folder name for download in a specific folder alongside blend file",
@@ -69,11 +63,8 @@ class ApiAddonPreferences(AddonPreferences):
         else:
             layout.operator("freesound.validate", text="Validate your API Key")
 
-        layout.prop(self, "freesound_project_folder")
-        if self.freesound_project_folder:
-            layout.prop(self, "freesound_project_folder_pattern")
-        else:
-            layout.prop(self, "freesound_download_folderpath")
+        layout.prop(self, "freesound_project_folder_pattern")
+        layout.prop(self, "freesound_download_folderpath")
 
 
 bl_info = {

--- a/freesound.py
+++ b/freesound.py
@@ -10,10 +10,6 @@ import datetime, time
 import aud
 from . import freesound_api
 
-# get addon preferences
-def get_addon_preferences():
-    addon = bpy.context.preferences.addons.get(__package__)
-    return getattr(addon, "preferences", None)        
 
 # create folder if needed
 def create_folder(folderpath):
@@ -37,6 +33,7 @@ def build_download_filepath(download_location, prefs, file_name):
         sound_filepath = join(freesound_folder, file_name)
     
     return sound_filepath
+
 
 class FREESOUND_UL_List(btypes.UIList):
     sound_id = 0
@@ -388,8 +385,6 @@ class Freesound_Add(btypes.Operator):
     bl_idname = 'freesound.add'
     bl_description = 'Add sound to the VSE at current frame'
     bl_options = {'REGISTER', 'UNDO'}
-
-    # poll out if project location and not saved
 
     def execute(self, context):
         addon_data = context.scene.freesound_data

--- a/freesound.py
+++ b/freesound.py
@@ -88,6 +88,7 @@ class Freesound_Play(btypes.Operator):
                     soundfile = sound_info.retrieve_preview(dirname(realpath(__file__)),
                                                     sound_info.name,
                                                     addon_data.high_quality)
+                # soundfile = sound filepath
                 addon_data.soundfile = soundfile
 
             device = aud.Device()
@@ -343,6 +344,7 @@ class Freesound_Add(btypes.Operator):
                                             sound_info.name,
                                             addon_data.high_quality)
         addon_data.soundfile = soundfile
+        # soundfile = sound filepath
 
         if not bpy.context.scene.sequence_editor:
             bpy.context.scene.sequence_editor_create()

--- a/freesound.py
+++ b/freesound.py
@@ -366,6 +366,8 @@ class Freesound_Add(btypes.Operator):
         if (not addon_data.freesound_list_loaded):
             return {'FINISHED'}
 
+        sound_name = addon_data.freesound_list[addon_data.active_list_item].name
+
         sound_id = FREESOUND_UL_List.get_sound_id(FREESOUND_UL_List)
         client = Freesound_Validate.get_client(Freesound_Validate)
         sound_info = client.get_sound(sound_id)
@@ -376,18 +378,25 @@ class Freesound_Add(btypes.Operator):
             preview_file = str(sound_info.previews.preview_lq_mp3.split("/")[-1])
 
         # build filepath
-        sound_filepath = build_download_filepath(addon_data.download_location, get_addon_preferences(), preview_file)
+        sound_filepath = build_download_filepath(
+            addon_data.download_location, 
+            context.preferences.addons[__package__].preferences, 
+            sound_name
+        )
         if sound_filepath == None:
             self.report({'WARNING'}, 'No folder pattern specified, check addon preferences')
             return {'FINISHED'}
 
         # get file if not existent
         if not isfile(sound_filepath):
+            print("Freesound Addon --- Downloading File : %s" % sound_name)
             sound_filepath = sound_info.retrieve_preview(dirname(sound_filepath),
                                         sound_info.name,
                                         addon_data.high_quality)
                                         
         addon_data.soundfile = sound_filepath
+
+        print("Freesound Addon --- Adding Sound Strip : %s" % sound_name)
 
         if not bpy.context.scene.sequence_editor:
             bpy.context.scene.sequence_editor_create()

--- a/freesound.py
+++ b/freesound.py
@@ -10,6 +10,12 @@ import datetime, time
 import aud
 from . import freesound_api
 
+# get addon preferences
+def get_addon_preferences():
+    addon = bpy.context.preferences.addons.get(__package__)
+    return getattr(addon, "preferences", None)        
+
+
 class FREESOUND_UL_List(btypes.UIList):
     sound_id = 0
     avg_rating = 0
@@ -333,7 +339,10 @@ class Freesound_Add(btypes.Operator):
     bl_description = 'Add sound to the VSE at current frame'
     bl_options = {'REGISTER', 'UNDO'}
 
+    # poll out if project location and not saved
+
     def execute(self, context):
+        prefs = get_addon_preferences()
         addon_data = context.scene.freesound_data
         if (not addon_data.freesound_list_loaded):
             return {'FINISHED'}

--- a/freesound.py
+++ b/freesound.py
@@ -203,6 +203,16 @@ class FreeSoundData(btypes.PropertyGroup):
         description="The type of license"
     )
 
+    download_location: EnumProperty(
+        items = [
+            ('PROJECT', 'Alongside Project', 'Alongside Project'),
+            ('COMMON', 'Common Folder', 'Common Folder'),
+        ],
+        name="Download Location",
+        default='PROJECT',
+        description="Where to store downloaded sound files"
+    )
+
     current_page: IntProperty(
         description = "Current Pager",
         default=1,

--- a/freesound.py
+++ b/freesound.py
@@ -10,14 +10,11 @@ import datetime, time
 import aud
 from . import freesound_api
 
-
-# create folder if needed
 def create_folder(folderpath):
     if not isdir(folderpath):
         os.makedirs(folderpath, exist_ok=True)
     return folderpath
 
-# build download filepath
 def build_download_filepath(download_location, prefs, file_name):
     if download_location=="PROJECT":
         if prefs.freesound_project_folder_pattern == "":
@@ -33,7 +30,6 @@ def build_download_filepath(download_location, prefs, file_name):
         sound_filepath = join(freesound_folder, file_name)
     
     return sound_filepath
-
 
 class FREESOUND_UL_List(btypes.UIList):
     sound_id = 0

--- a/freesound.py
+++ b/freesound.py
@@ -244,8 +244,8 @@ class FreeSoundData(btypes.PropertyGroup):
 
     preview_location: EnumProperty(
         items = [
-            ('PROJECT', 'Alongside Project', 'Alongside Project'),
-            ('COMMON', 'Common Folder', 'Common Folder'),
+            ('PROJECT', 'Project Directory', 'Preview will be stored in the project directory'),
+            ('COMMON', 'Common Directory', 'Preview will be stored in a common directory specified in preferences'),
         ],
         name="Preview Location",
         default='COMMON',
@@ -254,8 +254,8 @@ class FreeSoundData(btypes.PropertyGroup):
 
     download_location: EnumProperty(
         items = [
-            ('PROJECT', 'Alongside Project', 'Alongside Project'),
-            ('COMMON', 'Common Folder', 'Common Folder'),
+            ('PROJECT', 'Project Directory', 'Preview will be stored in the Project Directory'),
+            ('COMMON', 'Common Directory', 'Preview will be stored in a common directory specified in preferences'),
         ],
         name="Download Location",
         default='PROJECT',

--- a/freesound.py
+++ b/freesound.py
@@ -14,6 +14,12 @@ from . import freesound_api
 def get_addon_preferences():
     addon = bpy.context.preferences.addons.get(__package__)
     return getattr(addon, "preferences", None)        
+    
+# create folder if needed
+def create_folder(folderpath):
+    if not os.path.isdir(folderpath):
+        os.makedirs(folderpath, exist_ok=True)
+    return folderpath
 
 
 class FREESOUND_UL_List(btypes.UIList):

--- a/freesound.py
+++ b/freesound.py
@@ -356,6 +356,20 @@ class Freesound_Add(btypes.Operator):
         else:
             preview_file = str(sound_info.previews.preview_lq_mp3.split("/")[-1])
 
+        # build filepath
+        if addon_data.download_location=="PROJECT":
+            if prefs.freesound_project_folder_pattern != "":
+                blend_folder = os.path.dirname(bpy.data.filepath)
+                freesound_folder = os.path.join(blend_folder, prefs.freesound_project_folder_pattern)
+                sound_filepath = os.path.join(freesound_folder, preview_file)
+            else:
+                self.report({'WARNING'}, 'No folder pattern specified, check addon preferences')
+                return {'FINISHED'}
+        else:
+            # create dir if needed
+            freesound_folder = prefs.freesound_download_folderpath
+            sound_filepath = os.path.join(freesound_folder, preview_file)
+
         if (isfile(dirname(realpath(__file__)) + '/' + preview_file)):
             soundfile = dirname(realpath(__file__)) + '/' + preview_file
         else:

--- a/ui.py
+++ b/ui.py
@@ -19,7 +19,6 @@
 import bpy
 from bpy.types import Panel
 
-
 class FREESOUND_Panel(Panel):
     bl_space_type = 'SEQUENCE_EDITOR'
     bl_region_type = 'UI'
@@ -29,7 +28,7 @@ class FREESOUND_Panel(Panel):
 class FREESOUND_PT_Panel(FREESOUND_Panel):
     """Creates a Panel in the Object properties window"""
     bl_label = "Freesound"
-    
+
     @staticmethod
     def has_sequencer(context):
         return (context.space_data.view_type\

--- a/ui.py
+++ b/ui.py
@@ -48,13 +48,18 @@ class FREESOUND_PT_Panel(FREESOUND_Panel):
         layout = self.layout
 
         if not addon_prefs.freesound_access:
-            layout.label(text="No Valid Freesound Credentials")
-            layout.label(text="Check Addon Preferences")            
+            col = layout.column(align=True)
+            col.label(text="No Valid Freesound Credentials", icon="ERROR")
+            col.label(text="Check Addon Preferences")            
 
 
 class FREESOUND_PT_subpanel_search(FREESOUND_Panel):
     bl_parent_id = "FREESOUND_PT_Panel"
     bl_label = "Search"
+
+    @classmethod
+    def poll(cls, context):
+        return bpy.context.preferences.addons[__package__].preferences.freesound_access
 
     def draw(self, context):
         layout = self.layout

--- a/ui.py
+++ b/ui.py
@@ -56,9 +56,11 @@ class FREESOUND_PT_Panel(Panel):
 
         if (addon_prefs.freesound_access == True):
 
-            layout.prop(addon_data, "download_location")
-
             col = layout.column(align=True)
+
+            col.prop(addon_data, "preview_location")
+            col.prop(addon_data, "download_location")
+            col.separator()
 
             split2 = col.row(align=True)
             split2.prop(

--- a/ui.py
+++ b/ui.py
@@ -18,9 +18,7 @@
 
 import bpy
 from bpy.types import Panel
-from . import freesound_api
-from . import freesound
-import datetime
+
 
 class FREESOUND_Panel(Panel):
     bl_space_type = 'SEQUENCE_EDITOR'

--- a/ui.py
+++ b/ui.py
@@ -22,12 +22,14 @@ from . import freesound_api
 from . import freesound
 import datetime
 
-class FREESOUND_PT_Panel(Panel):
-    """Creates a Panel in the Object properties window"""
-    bl_label = "Freesound"
-    bl_category = "Audio"
+class FREESOUND_Panel(Panel):
     bl_space_type = 'SEQUENCE_EDITOR'
     bl_region_type = 'UI'
+
+
+class FREESOUND_PT_Panel(FREESOUND_Panel):
+    """Creates a Panel in the Object properties window"""
+    bl_label = "Freesound"
 
     @staticmethod
     def has_sequencer(context):
@@ -43,25 +45,31 @@ class FREESOUND_PT_Panel(Panel):
         layout.label(text="")
 
     def draw(self, context):
+        addon_prefs =  bpy.context.preferences.addons[__package__].preferences
+
+        layout = self.layout
+
+        if not addon_prefs.freesound_access:
+            layout.label(text="No Valid Freesound Credentials")
+            layout.label(text="Check Addon Preferences")            
+
+
+class FREESOUND_PT_subpanel_search(FREESOUND_Panel):
+    bl_parent_id = "FREESOUND_PT_Panel"
+    bl_label = "Search"
+
+    def draw(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-        sce = context.scene
 
-        frame_current = sce.frame_current
         addon_data = context.scene.freesound_data
         split = layout.split(factor=0.8, align=True)
         addon_prefs =  bpy.context.preferences.addons[__package__].preferences
 
-
         if (addon_prefs.freesound_access == True):
 
             col = layout.column(align=True)
-
-            col.prop(addon_data, "preview_location")
-            col.prop(addon_data, "download_location")
-            col.separator()
-
             split2 = col.row(align=True)
             split2.prop(
                 addon_data,
@@ -171,3 +179,21 @@ class FREESOUND_PT_Panel(Panel):
             split = split.split(factor=0.6, align=True)
             split.alignment = 'LEFT'                
             split.label(text=author)
+
+
+class FREESOUND_PT_subpanel_settings(FREESOUND_Panel):
+    bl_parent_id = "FREESOUND_PT_Panel"
+    bl_label = "Scene Settings"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        addon_data = context.scene.freesound_data
+
+        layout = self.layout
+
+        box = layout.box()
+        box.label(text="Download Locations")
+
+        col = box.column(align=True)
+        col.prop(addon_data, "preview_location", text="Preview")
+        col.prop(addon_data, "download_location", text="Download")

--- a/ui.py
+++ b/ui.py
@@ -56,6 +56,8 @@ class FREESOUND_PT_Panel(Panel):
 
         if (addon_prefs.freesound_access == True):
 
+            layout.prop(addon_data, "download_location")
+
             col = layout.column(align=True)
 
             split2 = col.row(align=True)

--- a/ui.py
+++ b/ui.py
@@ -23,12 +23,13 @@ from bpy.types import Panel
 class FREESOUND_Panel(Panel):
     bl_space_type = 'SEQUENCE_EDITOR'
     bl_region_type = 'UI'
+    bl_category = "Audio"
 
 
 class FREESOUND_PT_Panel(FREESOUND_Panel):
     """Creates a Panel in the Object properties window"""
     bl_label = "Freesound"
-
+    
     @staticmethod
     def has_sequencer(context):
         return (context.space_data.view_type\

--- a/ui.py
+++ b/ui.py
@@ -188,7 +188,6 @@ class FREESOUND_PT_subpanel_search(FREESOUND_Panel):
 class FREESOUND_PT_subpanel_settings(FREESOUND_Panel):
     bl_parent_id = "FREESOUND_PT_Panel"
     bl_label = "Scene Settings"
-    bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
         addon_data = context.scene.freesound_data


### PR DESCRIPTION
This PR adds some control over the download locations of the previz sounds and strip source sounds :
- In the addon preferences, 2 new properties, one is a folder pattern (name) if the user choose to store some datas next to the blend file, the other is a common folder where downloads are stored if user choose common folder option
![image](https://user-images.githubusercontent.com/26276003/146396551-b198e606-c5ab-4b5f-9051-639e01dc6902.png)
- In the UI, two options, one for the previz location, the other for the download location. Both are 2 entries enum prop with "Common" and "Project" options to store sound files in a folder alongside project, or common one (both specified in addon prefs)
![image](https://user-images.githubusercontent.com/26276003/146396876-f0942434-fac5-4037-b8d2-b4024d347212.png)
- I also fixed the "already existing file" behavior in play and add sound operators by using name of sound file from the addon_data list of sounds, so the addon does not re download the sound if it finds it.
- The addon shows warning message if the sound file is supposed to be saved alongside blend file, but blend file is not saved
- The addon shows warning message if the sound file is supposed to be saved alongside blend file, but folder name pattern from prefs is blank
- The addon creates recursively the folders on-the-fly when needed 
- Default for the common folder is located in blender user datafiles folder
- I bumped the version and adds tin2tin and myself as authors in the bl_info, hope this is ok
- Added a few prints in the play and add operators (downloading, playing, adding strips)

I tried to keep the code consistent without altering existing code, i added 2 commonly used functions at the start of the freesound.py file and a few import `from os.path`

Cheers !